### PR TITLE
Add support for ROS v6.43+ AES128-CTR-SHA256 format

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,4 +104,4 @@ For each entry:
 
 # Dependences
 - argparse
-- pycrypto
+- [pyca/cryptography](https://cryptography.io/en/latest/installation.html#installation)

--- a/ROSbackup.py
+++ b/ROSbackup.py
@@ -14,6 +14,7 @@ MAGIC_ENCRYPTED_RC4 = 0x7291A8EF
 MAGIC_ENCRYPTED_AES = 0X7391A8EF   
 MAGIC_PLAINTEXT = 0xB1A1AC88
 RC4_SKIP = 0x300
+AES_SKIP = 0x10
 
 #####################
 # support functions #
@@ -27,21 +28,19 @@ def get_header(input_file):
 
 def get_salt(input_file):
     input_file.seek(8, 0)
-    data = input_file.read(32)
-    salt = struct.unpack('<32s', data)
-    return salt[0]
+    return input_file.read(32)
 
 def get_signature(input_file):
     input_file.seek(40, 0)
-    data = input_file.read(32)
-    sign = struct.unpack('<32s', data)
-    return sign[0]
+    return input_file.read(32)
 
-def get_magic_check(input_file):
+def get_magic_check_rc4(input_file):
     input_file.seek(40, 0)
-    data = input_file.read(4)
-    magic_check = struct.unpack('<4s', data)
-    return magic_check[0]
+    return input_file.read(4)
+
+def get_magic_check_aes(input_file):
+    input_file.seek(72, 0)
+    return input_file.read(4)
 
 def check_password(cipher, magic_check):
     data = cipher.update(magic_check)
@@ -58,6 +57,20 @@ def setup_cipher_rc4(salt, password, encrypt = False):
     cryptor = cipher.encryptor() if encrypt else cipher.decryptor()
     cryptor.update(bytes(RC4_SKIP))
     return cryptor
+
+def setup_cipher_aes(salt, password, encrypt = False):
+    hash = Hash(SHA256(), default_backend())
+    hash.update(salt + bytes(password, 'ascii'))
+    cipher = Cipher(algorithms.AES(hash.finalize()[:16]), modes.CTR(salt[:16]), default_backend())
+    cryptor = cipher.encryptor() if encrypt else cipher.decryptor()
+    cryptor.update(bytes(AES_SKIP))
+    return cryptor
+
+def setup_hmac_aes(salt, password):
+    hash = Hash(SHA256(), default_backend())
+    hash.update(salt + bytes(password, 'ascii'))
+    hmac = HMAC(hash.finalize()[16:], SHA256(), default_backend())
+    return hmac
 
 def extract_data(input_file):
     raw_len = input_file.read(4)
@@ -118,6 +131,26 @@ def decrypt_backup_rc4(input_file, output_file, cipher):
     output_file.seek(4, 0)
     output_file.write(length)
 
+def decrypt_backup_aes(input_file, output_file, cipher, hmac):
+    input_file.seek(72, 0) # skip magic, length, salt/nonce, hmac (but not magic_check)
+    output_file.seek(0, 0)
+    hmac.update(input_file.read(4)) # encrypted magic_check
+    magic = struct.pack('<I', MAGIC_PLAINTEXT)
+    output_file.write(magic + bytes(4)) # magic, length offset
+
+    while True:
+        chunk = input_file.read(1024)
+        if not chunk:
+            break
+        hmac.update(chunk)
+        output_file.write(cipher.update(chunk))
+
+    length = struct.pack('<I', output_file.tell()) # length
+    output_file.seek(4, 0)
+    output_file.write(length)
+
+    return hmac.finalize()
+
 def encrypt_backup_rc4(input_file, output_file, cipher, salt):
     input_file.seek(8, 0) # skip magic, length
     output_file.seek(0, 0)
@@ -136,6 +169,32 @@ def encrypt_backup_rc4(input_file, output_file, cipher, salt):
     length = struct.pack('<I', output_file.tell()) # length
     output_file.seek(4, 0)
     output_file.write(length)
+
+def encrypt_backup_aes(input_file, output_file, cipher, hmac, salt):
+    input_file.seek(8, 0) # skip magic, length
+    output_file.seek(0, 0)
+    magic = struct.pack('<I', MAGIC_ENCRYPTED_AES)
+    output_file.write(magic + bytes(4) + salt + bytes(32)) # magic, length offset, salt/nonce, hmac offset
+
+    magic_check = struct.pack('<I', MAGIC_PLAINTEXT)
+    ciphertext = cipher.update(magic_check)
+    hmac.update(ciphertext)
+    output_file.write(ciphertext)
+
+    while True:
+        chunk = input_file.read(1024)
+        if not chunk:
+            break
+        ciphertext = cipher.update(chunk)
+        hmac.update(ciphertext)
+        output_file.write(ciphertext)
+
+    length = struct.pack('<I', output_file.tell()) # length
+    output_file.seek(4, 0)
+    output_file.write(length)
+
+    output_file.seek(40, 0)
+    output_file.write(hmac.finalize())
 
 def unpack_files(input_file, file_length, path):
     count = 0
@@ -184,11 +243,16 @@ def pack_files(path, file_names, output_file):
 # parallel bruteforcing function
 found = False
 counter = 0
-def brute(namespace, salt, magic_check, password):
+def brute(namespace, salt, magic_check, magic, password):
     global found
 
     if not found:
-        cipher = setup_cipher_rc4(salt, password.strip())
+        if magic == MAGIC_ENCRYPTED_RC4:
+            cipher = setup_cipher_rc4(salt, password.strip())
+        elif magic == MAGIC_ENCRYPTED_AES:
+            cipher = setup_cipher_aes(salt, password.strip())
+        else:
+            assert False
         if check_password(cipher, magic_check):
             found = True
             namespace.found = found
@@ -214,17 +278,17 @@ def info(input_file):
         print("Length:", length, "bytes")
         salt = get_salt(input_file)
         print("Salt (hex):", salt.hex())
-        magic_check = get_magic_check(input_file)
+        magic_check = get_magic_check_rc4(input_file)
         print("Magic Check (hex):", magic_check.hex())
 
     elif magic == MAGIC_ENCRYPTED_AES:
-        print("RouterOS Encrypted Backup (aes-sha256)")
+        print("RouterOS Encrypted Backup (aes128-ctr-sha256)")
         print("Length:", length, "bytes")
         salt = get_salt(input_file)
         print("Salt (hex):", salt.hex())
         signature = get_signature(input_file)
         print("Signature: ", signature.hex())
-        magic_check = get_magic_check(input_file)
+        magic_check = get_magic_check_aes(input_file)
         print("Magic Check (hex):", magic_check.hex())
 
     elif magic == MAGIC_PLAINTEXT:
@@ -245,7 +309,7 @@ def decrypt(input_file, output_file, password):
             print("Length:", length, "bytes")
             salt = get_salt(input_file)
             print("Salt (hex):", salt.hex())
-            magic_check = get_magic_check(input_file)
+            magic_check = get_magic_check_rc4(input_file)
             print("Magic Check (hex):", magic_check.hex())
 
             cipher = setup_cipher_rc4(salt, password)
@@ -260,15 +324,29 @@ def decrypt(input_file, output_file, password):
                 print("Cannot decrypt!")
 
         elif magic == MAGIC_ENCRYPTED_AES:
-            print("RouterOS Encrypted Backup (aes-sha256)")
+            print("RouterOS Encrypted Backup (aes128-ctr-sha256)")
             print("Length:", length, "bytes")
             salt = get_salt(input_file)
             print("Salt (hex):", salt.hex())
             signature = get_signature(input_file)
             print("Signature: ", signature.hex())
-            magic_check = get_magic_check(input_file)
+            magic_check = get_magic_check_aes(input_file)
             print("Magic Check (hex):", magic_check.hex())
-            print("Aes-sha256 decryption NOT yet supported")
+
+            cipher = setup_cipher_aes(salt, password)
+
+            if check_password(cipher, magic_check):
+                print("Correct password!")
+                print("Decrypting...")
+                hmac = setup_hmac_aes(salt, password)
+                calculated_sig = decrypt_backup_aes(input_file, output_file, cipher, hmac)
+                if calculated_sig != signature:
+                    print("Decryption completed, but HMAC check failed - file has been modified!")
+                else:
+                    print("Decrypted correctly")
+            else:
+                print("Wrong password!")
+                print("Cannot decrypt!")
 
         elif magic == MAGIC_PLAINTEXT:
             print("RouterOS Plaintext Backup")
@@ -302,8 +380,18 @@ def encrypt(input_file, output_file, encryption, password):
                 print("Encrypting with rc4-sha1...")
                 encrypt_backup_rc4(input_file, output_file, cipher, salt)
                 print("Encrypted correctly")
+            elif encryption == "AES":
+                salt = make_salt(32)
+                print("Generated Salt (hex):", salt.hex())
+
+                cipher = setup_cipher_aes(salt, password, encrypt=True)
+                hmac = setup_hmac_aes(salt, password)
+
+                print("Encrypting with aes128-ctr-sha256...")
+                encrypt_backup_aes(input_file, output_file, cipher, hmac, salt)
+                print("Encrypted correctly")
             else:
-                print("Aes-sha256 encryption NOT yet supported")
+                assert False
 
         else:
             print("Invalid file!")
@@ -358,62 +446,71 @@ def bruteforce(input_file, wordlist_file, parallel=False):
             print("Length:", length, "bytes")
             salt = get_salt(input_file)
             print("Salt (hex):", salt.hex())
-            magic_check = get_magic_check(input_file)
+            magic_check = get_magic_check_rc4(input_file)
             print("Magic Check (hex):", magic_check.hex())
 
-            if parallel:
-
-                print("Parallel brute forcing...")
-
-                from multiprocessing import Pool, Manager
-                from functools import partial
-
-                global found
-                found = False
-
-                namespace = Manager().Namespace()
-                namespace.found = found
-                namespace.password = None
-
-                Pool().map(partial(brute, namespace, salt, magic_check), wordlist_file)
-
-                found = namespace.found
-                password = namespace.password
-
-            else:
-
-                print("Brute forcing...")
-
-                found = False
-                for password in wordlist_file:
-                    cipher = setup_cipher_rc4(salt, password.strip())
-                    if check_password(cipher, magic_check):
-                        found = True
-                        break
-
-            if found:
-                print("Password found:", password)
-            else:
-                print("Password NOT found")
-
         elif magic == MAGIC_ENCRYPTED_AES:
-            print("RouterOS Encrypted Backup (aes-sha256)")
+            print("RouterOS Encrypted Backup (aes128-ctr-sha256)")
             print("Length:", length, "bytes")
             salt = get_salt(input_file)
             print("Salt (hex):", salt.hex())
             signature = get_signature(input_file)
             print("Signature: ", signature.hex())
-            magic_check = get_magic_check(input_file)
+            magic_check = get_magic_check_aes(input_file)
             print("Magic Check (hex):", magic_check.hex())
-            print("Bruteforce aes-sha256 NOT yet supported")
-
-        elif magic == MAGIC_PLAINTEXT:
-            print("RouterOS Plaintext Backup")
-            print("No decryption needed!")
 
         else:
-            print("Invalid file!")
-            print("Cannot decrypt!")
+            if magic == MAGIC_PLAINTEXT:
+                print("RouterOS Plaintext Backup")
+                print("No decryption needed!")
+            else:
+                print("Invalid file!")
+                print("Cannot decrypt!")
+
+            input_file.close()
+            wordlist_file.close()
+            return
+
+        if parallel:
+
+            print("Parallel brute forcing...")
+
+            from multiprocessing import Pool, Manager
+            from functools import partial
+
+            global found
+            found = False
+
+            namespace = Manager().Namespace()
+            namespace.found = found
+            namespace.password = None
+
+            Pool().map(partial(brute, namespace, salt, magic_check, magic), wordlist_file)
+
+            found = namespace.found
+            password = namespace.password
+
+        else:
+
+            print("Brute forcing...")
+
+            found = False
+            for password in wordlist_file:
+                if magic == MAGIC_ENCRYPTED_RC4:
+                    cipher = setup_cipher_rc4(salt, password.strip())
+                elif magic == MAGIC_ENCRYPTED_AES:
+                    cipher = setup_cipher_aes(salt, password.strip())
+                else:
+                    assert False
+                if check_password(cipher, magic_check):
+                    found = True
+                    break
+
+        if found:
+            print("Password found:", password)
+        else:
+            print("Password NOT found")
+
 
         input_file.close()
         wordlist_file.close()

--- a/ROSbackup.py
+++ b/ROSbackup.py
@@ -427,12 +427,12 @@ def parse_cli():
 
     decryptParser = subparser.add_parser('decrypt', help='Decrypt backup')
     decryptParser.add_argument('-i', '--input', required=True, metavar='INPUT_FILE', type=FileType('rb'))
-    decryptParser.add_argument('-o', '--output', required=True, metavar='OUTPUT_FILE', type=FileType('wb'))
+    decryptParser.add_argument('-o', '--output', required=True, metavar='OUTPUT_FILE', type=FileType('xb'))
     decryptParser.add_argument('-p', '--password', required=True, metavar='PASSWORD')
 
     encryptParser = subparser.add_parser('encrypt', help='Encrypt backup')
     encryptParser.add_argument('-i', '--input', required=True, metavar='INPUT_FILE', type=FileType('rb'))
-    encryptParser.add_argument('-o', '--output', required=True, metavar='OUTPUT_FILE', type=FileType('wb'))
+    encryptParser.add_argument('-o', '--output', required=True, metavar='OUTPUT_FILE', type=FileType('xb'))
     encryptParser.add_argument('-e', '--encryption', required=True, metavar='ENCRYPTION', action='store', choices=['RC4','AES'])
     encryptParser.add_argument('-p', '--password', required=True, metavar='PASSWORD')
 
@@ -442,7 +442,7 @@ def parse_cli():
 
     packParser = subparser.add_parser('pack', help='Unpack backup')
     packParser.add_argument('-d', '--directory', required=True, metavar='PACK_DIRECTORY')
-    packParser.add_argument('-o', '--output', required=True, metavar='OUTPUT_FILE', type=FileType('wb'))
+    packParser.add_argument('-o', '--output', required=True, metavar='OUTPUT_FILE', type=FileType('xb'))
 
     bruteforceParser = subparser.add_parser('bruteforce', help='Bruteforce backup password')
     bruteforceParser.add_argument('-i', '--input', required=True, metavar='INPUT_FILE', type=FileType('rb'))

--- a/ROSbackup.py
+++ b/ROSbackup.py
@@ -3,7 +3,6 @@
 # RouterOS Backup Tools by BigNerd95
 
 import sys, os, struct
-from random import randrange
 from argparse import ArgumentParser, FileType
 from Crypto.Cipher import ARC4, AES
 from Crypto.Hash import SHA, SHA256, HMAC
@@ -49,7 +48,7 @@ def check_password(cipher, magic_check):
     return decrypted_magic_check[0] == MAGIC_PLAINTEXT
 
 def make_salt(size):
-    return bytes([randrange(256) for _ in range(size)])
+    return os.urandom(size)
 
 def setup_cipher_rc4(salt, password):
     key = SHA.new(salt + bytes(password, 'ascii')).digest()

--- a/ROSbackup.py
+++ b/ROSbackup.py
@@ -396,7 +396,7 @@ def bruteforce(input_file, wordlist_file, parallel=False):
             else:
                 print("Password NOT found")
 
-        if magic == MAGIC_ENCRYPTED_AES:
+        elif magic == MAGIC_ENCRYPTED_AES:
             print("RouterOS Encrypted Backup (aes-sha256)")
             print("Length:", length, "bytes")
             salt = get_salt(input_file)

--- a/ROSbackup.py
+++ b/ROSbackup.py
@@ -182,8 +182,10 @@ def pack_files(path, file_names, output_file):
     output_file.write(length)
 
 # parallel bruteforcing function
+found = False
+counter = 0
 def brute(namespace, salt, magic_check, password):
-    global found # init in caller function "bruteforce"
+    global found
 
     if not found:
         cipher = setup_cipher_rc4(salt, password.strip())
@@ -193,7 +195,7 @@ def brute(namespace, salt, magic_check, password):
             namespace.password = password
 
         # communication drastically drop down the performance, so we make it only once each 1000 iterations
-        global counter # init in caller function "bruteforce"
+        global counter
         counter += 1
         if counter == 1000: # <-- increase 1000 if all CPU are not at 100%
             counter = 0
@@ -366,9 +368,7 @@ def bruteforce(input_file, wordlist_file, parallel=False):
                 from multiprocessing import Pool, Manager
                 from functools import partial
 
-                global counter
                 global found
-                counter = 0
                 found = False
 
                 namespace = Manager().Namespace()


### PR DESCRIPTION
This adds support for the AES128-CTR-SHA256 format. It also fixes a handful of bugs (each in a separate commit), and makes a couple of other changes which may or may not be a good idea:

* Switch from PyCrypto to [pyca/cryptography](https://cryptography.io/)

    PyCrypto can be difficult to install, and hasn't been under active development since 2013. pyca/cryptography is easy to install on a bunch of platforms (including various Linux distros, Windows, and MacOS), has been under active development since 2013, and is maintained by some of the same folk who maintain pynacl and pyopenssl.

* Don't overwrite already-existing files when decrypting or encrypting.

    This one's just a matter of preference....

If you'd rather I remove any of the commits from the PR, or make any other changes, let me know!

I tested this with circa-2016 versions in the hopes that it keeps decent backwards-compatibility (Python 3.5 and cryptography v1.2.3), and very briefly with Python 3.8 and the latest cryptography (v3.2.1), but haven't done a much testing beyond that.

closes #7, closes #8, closes #14, closes #15