### PR TITLE
Some wordlists contain non-ascii symbols and they cause crash

### DIFF
--- a/ROSbackup.py
+++ b/ROSbackup.py
@@ -50,6 +50,9 @@ def check_password(cipher, magic_check):
 def make_salt(size):
     return os.urandom(size)
 
+def is_ascii(s):
+    return all(ord(c) < 128 for c in s)
+
 def setup_cipher_rc4(salt, password, encrypt = False):
     hash = Hash(SHA1(), default_backend())
     hash.update(salt + bytes(password, 'ascii'))
@@ -496,6 +499,9 @@ def bruteforce(input_file, wordlist_file, parallel=False):
 
             found = False
             for password in wordlist_file:
+                if not is_ascii(password.strip()):
+                    print("Not ASCII password '"+password.strip()+"' in wordlist, skipping")
+                    continue
                 if magic == MAGIC_ENCRYPTED_RC4:
                     cipher = setup_cipher_rc4(salt, password.strip())
                 elif magic == MAGIC_ENCRYPTED_AES:


### PR DESCRIPTION
This was original crash:

./ROSbackup.py bruteforce -i cod.backup -w hashash.in-wordlist.txt 
** Bruteforce Backup Password **
RouterOS Encrypted Backup (rc4-sha1)
Length: 21360 bytes
Salt (hex): 4e28a40e99993c50587beb7af2a3da5500000000000000000000000000000000
Magic Check (hex): 6dc1b597
Brute forcing...
Traceback (most recent call last):
  File "./ROSbackup.py", line 570, in <module>
    main()
  File "./ROSbackup.py", line 567, in main
    bruteforce(args.input, args.wordlist, args.parallel)
  File "./ROSbackup.py", line 500, in bruteforce
    cipher = setup_cipher_rc4(salt, password.strip())
  File "./ROSbackup.py", line 55, in setup_cipher_rc4
    hash.update(salt + bytes(password, 'ascii'))
UnicodeEncodeError: 'ascii' codec can't encode characters in position 6-7: ordinal not in range(128)
